### PR TITLE
Added links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ It is optimized for building complex data-dense interfaces for desktop applicati
 
 All the rights belongs to BlueprintJS team.
 
+## Links
+- Official Blueprint documentation: https://blueprintjs.com/docs/
+- Pypi homepage: https://pypi.org/project/dash-blueprint-components/
+- Dash blueprint components docs: https://dash-blueprint-components.com/blueprint/
+
 ## Installation
 
 ```python


### PR DESCRIPTION
Added links to associated pages. Started mainly because the pypi page for the dash blueprint components did not appear in the top results in a Google search for dash blueprint components. It did contain a link to the library dash blueprints, which is something else. As I added links, I also included links to the docs page and the official blueprint documentation